### PR TITLE
Improve Windows compatibility

### DIFF
--- a/hledger_lots/__main__.py
+++ b/hledger_lots/__main__.py
@@ -2,7 +2,7 @@ from .cli import cli
 
 
 def main():
-    cli(obj=dict())
+    cli(obj=dict(), auto_envvar_prefix="HLEDGER_LOTS")
 
 
 if __name__ == "__main__":

--- a/hledger_lots/avg.py
+++ b/hledger_lots/avg.py
@@ -101,7 +101,7 @@ def avg_sell(
     {revenue_account}"""
 
     comm = ["hledger", "-f-", "print", "--explicit"]
-    txn_proc = subprocess.run(comm, input=txn_hl.encode(), capture_output=True)
+    txn_proc = subprocess.run(comm, input=txn_hl, capture_output=True, encoding="utf8")
 
-    txn_print: str = txn_proc.stdout.decode("utf8")
+    txn_print: str = txn_proc.stdout
     return txn_print

--- a/hledger_lots/fifo.py
+++ b/hledger_lots/fifo.py
@@ -112,10 +112,6 @@ def txn2hl(
 
     txn_hl += f"    {revenue_account}   "
     comm = ["hledger", "-f-", "print", "--explicit"]
-    txn_proc = subprocess.run(
-        comm,
-        input=txn_hl.encode(),
-        capture_output=True,
-    )
-    txn_print: str = txn_proc.stdout.decode("utf8")
+    txn_proc = subprocess.run(comm, input=txn_hl, capture_output=True, encoding="utf8")
+    txn_print: str = txn_proc.stdout
     return txn_print

--- a/hledger_lots/hl.py
+++ b/hledger_lots/hl.py
@@ -31,11 +31,13 @@ def hledger2txn(
     if no_desc:
         comm.append(f"not:desc:{no_desc}")
 
-    hl_proc = subprocess.run(comm, stdin=sys.stdin, capture_output=True)
+    hl_proc = subprocess.run(
+        comm, stdin=sys.stdin, capture_output=True, encoding="utf8"
+    )
     if hl_proc.returncode != 0:
-        raise ValueError(hl_proc.stderr.decode("utf8"))
+        raise ValueError(hl_proc.stderr)
 
-    hl_data = hl_proc.stdout.decode("utf8")
+    hl_data = hl_proc.stdout
     txns_list = json.loads(hl_data)
 
     txns = [

--- a/hledger_lots/info.py
+++ b/hledger_lots/info.py
@@ -41,8 +41,8 @@ def get_last_price(files_comm: List[str], commodity: str):
         f"cur:{commodity}",
         "--infer-reverse-prices",
     ]
-    prices_proc = subprocess.run(prices_comm, capture_output=True)
-    prices_str = prices_proc.stdout.decode("utf8")
+    prices_proc = subprocess.run(prices_comm, capture_output=True, encoding="utf8")
+    prices_str = prices_proc.stdout
 
     if prices_str == "":
         return (None, None)
@@ -65,8 +65,8 @@ def get_last_price(files_comm: List[str], commodity: str):
 def get_commodities(journals: Tuple[str, ...]):
     files_comm = get_files_comm(journals)
     comm = ["hledger", *files_comm, "commodities"]
-    commodities_proc = subprocess.run(comm, capture_output=True)
-    commodities_str = commodities_proc.stdout.decode("utf8")
+    commodities_proc = subprocess.run(comm, capture_output=True, encoding="utf8")
+    commodities_str = commodities_proc.stdout
 
     commodities_list = [com for com in commodities_str.split("\n") if com != ""]
     return commodities_list

--- a/hledger_lots/lib.py
+++ b/hledger_lots/lib.py
@@ -32,11 +32,11 @@ class CostMethodError(Exception):
         super().__init__(self.message)
 
 
-def get_file_from_stdin():
+def get_file_from_stdin(newlines: Optional[str]):
     tmp_file = tempfile.NamedTemporaryFile(suffix=".journal", delete=False)
     name = tmp_file.name
 
-    with open(tmp_file.name, "w") as f:
+    with open(tmp_file.name, "w", newline=newlines) as f:
         for line in sys.stdin:
             f.write(line)
 

--- a/hledger_lots/prompt.py
+++ b/hledger_lots/prompt.py
@@ -142,20 +142,20 @@ class Prompt:
         if self.no_desc and self.no_desc != "":
             command = [*command, f"not:desc:{self.no_desc}"]
 
-        proc = subprocess.run(command, capture_output=True)
+        proc = subprocess.run(command, capture_output=True, encoding="utf8")
         if proc.returncode != 0:
-            raise subprocess.SubprocessError(proc.stderr.decode("utf8"))
+            raise subprocess.SubprocessError(proc.stderr)
 
-        result = proc.stdout.decode("utf8")
+        result = proc.stdout
         return result
 
     def run_hledger_no_query_desc(self, *comm: str):
         command = ["hledger", *self.files_comm, *comm]
-        proc = subprocess.run(command, capture_output=True)
+        proc = subprocess.run(command, capture_output=True, encoding="utf8")
         if proc.returncode != 0:
-            raise subprocess.SubprocessError(proc.stderr.decode("utf8"))
+            raise subprocess.SubprocessError(proc.stderr)
 
-        result = proc.stdout.decode("utf8")
+        result = proc.stdout
         return result
 
     def get_infos(self):

--- a/hledger_lots/prompt_buy.py
+++ b/hledger_lots/prompt_buy.py
@@ -129,13 +129,11 @@ class PromptBuy(prompt.Prompt):
 
         comm = ["hledger", "-f-", "print", "--explicit"]
         txn_proc = subprocess.run(
-            comm,
-            input=txn_raw.encode(),
-            capture_output=True,
+            comm, input=txn_raw, capture_output=True, encoding="utf8"
         )
         if txn_proc.returncode != 0:
-            err = txn_proc.stderr.decode("utf8")
+            err = txn_proc.stderr
             raise prompt.PromptError(err)
 
-        txn_print: str = txn_proc.stdout.decode("utf8")
+        txn_print: str = txn_proc.stdout
         return txn_print


### PR DESCRIPTION
I wasn’t able to use hledger-lots as-is on Windows because of issues with line endings. This was especially problematic since it also needs to parse the output of hledger, so things can go wrong when reading as well as when writing.

In particular, the second case is more complex for me. I use Emacs and Linux line endings. hledger-lots (correctly) writes data without specifying a line ending, so Python converts it to the system separator, which is `\r\n` here, and I end up with oddities in my journal. I could tell Python not to convert it, but then it might not function correctly for anyone using Windows line endings.

This PR adds a <kbd>--newlines</kbd> (or <kbd>-l</kbd>) option to control which line endings are used when writing data, and correctly parses the various line endings when reading data. It also enables click’s support for reading options from environment variables (<code>HLEDGER_LOT_<var>OPTION</var></code>), which I thought would help in cases like mine (but is not necessary for the main purpose of the PR, if you’d rather not have it enabled).